### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> This project is no longer being maintained as of March 2026.
+
 ### A fully functional starter kit to store realtime messages from Ably into Airtable via WebHooks
 
 This project shows how to use [Airtable](https://airtable.com/) to store realtime messages using a group chat app built with [Ably Realtime](https://www.ably.io/). 


### PR DESCRIPTION
## Summary
- Adds a deprecation notice to the top of the README indicating the project is no longer maintained as of March 2026

## Context
- Part of [DX-926](https://ably.atlassian.net/browse/DX-926) to deprecate and archive old ably-labs projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-926]: https://ably.atlassian.net/browse/DX-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ